### PR TITLE
Add `settings.misc.filter` and `ignore_filters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `settings.misc.filter` and `ignore_filters` argument.
+
 ## [0.4.0] - 2024-06-17
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `settings.misc.filter` and `ignore_filters` argument.
 
+### Changed
+- The `plot()`-function now treats data of length two as a limits-tuple for display purposes.
+
 ## [0.4.0] - 2024-06-17
 
 ### Deprecated

--- a/examples/filter_before_all.py
+++ b/examples/filter_before_all.py
@@ -1,0 +1,43 @@
+"""Filters: minimum ``before='all'`` size.
+==========================================
+
+Arbitrary filters can be applied for all applications using the :attr:`time_split.settings.misc.filter` option. Must be
+a predicate ``(start, mid, end) -> bool``. Consider using :func:`functools.cache` if your predicate is expensive.
+"""
+
+from rics import configure_stuff
+from time_split import log_split_progress, plot, settings, split
+
+configure_stuff(datefmt="")
+
+data = ("2022-02", "2022-03")
+config = dict(schedule="7d", before="all", after="5d", available=data)
+
+plot(**config, bar_labels="days")
+
+for fold in log_split_progress(split(**config), logger="my-logger"):
+    print("Doing work..")
+
+# %%
+# By setting :attr:`settings.misc.filter <time_split.settings.misc.filter>`, arbitrary conditions may be
+# forced on the generated folds.
+
+
+def at_least_10_days(start, mid, end):
+    return (mid - start).days >= 10
+
+
+# %%
+# Enforcing 10 days of training data.
+
+
+settings.misc.filter = at_least_10_days
+plot(**config, bar_labels="days", show_removed=True)
+
+for fold in log_split_progress(split(**config), logger="my-logger"):
+    print("Doing work..")
+
+# %%
+# The configuration in :mod:`time_split.settings` are global, so changes made will remain in effect for all
+# callers until the original value is reset.
+settings.misc.filter = None

--- a/examples/n_splits_dynamic_before_and_after.py
+++ b/examples/n_splits_dynamic_before_and_after.py
@@ -22,7 +22,7 @@ config = dict(
 plot(**config, show_removed=True)
 # %%
 # Any non-zero integer before/after-range may be used. Setting ``show_removed=True`` forces plotting of folds that would
-# be silently discarded by the :func:`~rics.ml.time_split.split`-function. Later folds are preferred.
+# be silently discarded by the :func:`~time_split.split`-function. Later folds are preferred.
 
 for fold in log_split_progress(split(**config), logger="my-logger"):
     print("Doing work..")

--- a/examples/plotting_with_metrics.py
+++ b/examples/plotting_with_metrics.py
@@ -50,8 +50,8 @@ bar_labels = [
     )
     for date, fold_metrics in metrics.items()
 ]
-
 ax = plot(**config, bar_labels=bar_labels)
+ax.figure.set_size_inches(20, 6)
 
 # %%
 # Bar height is not based on `bar_labels`, so make sure to configure e.g. ``rcParams["figure.figsize"]`` beforehand when

--- a/examples/ruff.toml
+++ b/examples/ruff.toml
@@ -1,0 +1,2 @@
+[lint]
+ignore = ["ANN001"]

--- a/examples/timedelta_schedule_and_after.py
+++ b/examples/timedelta_schedule_and_after.py
@@ -19,7 +19,7 @@ for fold in log_split_progress(split(**config), logger="my-logger"):
     print("Doing work..")
 
 # %%
-# Setting :attr:`settings.misc.snap_to_end <rics.ml.time_split.settings.misc.snap_to_end>` to ``False`` will adopt the
+# Setting :attr:`settings.misc.snap_to_end <time_split.settings.misc.snap_to_end>` to ``False`` will adopt the
 # default behavior used by :func:`pandas.date_range`.
 
 settings.misc.snap_to_end = False
@@ -29,6 +29,6 @@ for fold in log_split_progress(split(**config), logger="my-logger"):
     print("Doing work..")
 
 # %%
-# The configuration in :mod:`rics.ml.time_split.settings` are global, so changes made will remain in effect for all
+# The configuration in :mod:`time_split.settings` are global, so changes made will remain in effect for all
 # callers until the original value is reset.
 settings.misc.snap_to_end = True

--- a/src/time_split/_backend/_splitter.py
+++ b/src/time_split/_backend/_splitter.py
@@ -2,11 +2,11 @@ import logging
 from dataclasses import asdict, dataclass
 from typing import cast, get_args
 
-from pandas import Timedelta, Timestamp
+from pandas import Timedelta
 from rics.misc import format_kwargs
 
-from time_split._compat import fmt_sec
-
+from .._frontend._to_string import stringify
+from ..settings import misc as settings
 from ..types import (
     DatetimeIndexSplitterKwargs,
     DatetimeIterable,
@@ -128,20 +128,8 @@ class DatetimeIndexSplitter:
         return [s for s in splits if settings.filter(*s)]
 
     def _log_expansion(self, original: LimitsTuple, *, expanded: LimitsTuple) -> None:
-        if original == expanded:
+        if original == expanded or not LOGGER.isEnabledFor(logging.INFO):
             return
-
-        if not LOGGER.isEnabledFor(logging.INFO):
-            return
-
-        def stringify(old: Timestamp, *, new: Timestamp) -> str:
-            from .._frontend._to_string import _PrettyTimestamp
-
-            retval = f"{old} -> "
-            if old == new:
-                return retval + "<no change>"
-            diff = (new - old).total_seconds()
-            return retval + f"{_PrettyTimestamp(new).auto} ({'+' if diff > 0 else '-'}{fmt_sec(abs(diff))})"
 
         LOGGER.info(
             f"Available data limits have been expanded (since expand_limits={self.expand_limits!r}):\n"

--- a/src/time_split/_docstrings.py
+++ b/src/time_split/_docstrings.py
@@ -37,6 +37,7 @@ _DOCSTRINGS = {
     "n_splits": "Maximum number of folds, preferring folds later in the schedule.",
     "available": "Binds `schedule` to a range.",
     "expand_limits": f'A {_OFFSET} used to expand `available` data to its likely `"true"` limits. Pass ``False`` to disable.',
+    "ignore_filters": "Set to ignore filtering parameters (e.g. `step`) and global configuration.",
     "USER_GUIDE": (
         "For more information about the `schedule`, `before/after` and `expand_limits`-arguments"
         ", see the :ref:`User guide`."

--- a/src/time_split/_frontend/_plot.py
+++ b/src/time_split/_frontend/_plot.py
@@ -66,6 +66,7 @@ def plot(
     n_splits: int = 0,
     available: DatetimeIterable | None = None,
     expand_limits: ExpandLimits = "auto",
+    ignore_filters: bool = False,
     # Split plot args
     bar_labels: str | Rows | list[tuple[str, str]] | bool = True,
     show_removed: bool = False,
@@ -86,6 +87,7 @@ def plot(
         available: {available} If `bar_labels` is given but is not a ``list``,
             this data will be used to compute fold sizes.
         expand_limits: {expand_limits}
+        ignore_filters: {ignore_filters}
         bar_labels: Labels to draw on the bars. If you pass a string, it will be interpreted as a time unit (see
             :ref:`pandas:timeseries.offset_aliases` for valid frequency strings). Bars will show the number of units
             contained. Pass `'rows'` to simply count the numbers of elements in `data` (if given). To write custom
@@ -116,6 +118,7 @@ def plot(
         step=step,
         n_splits=n_splits,
         expand_limits=expand_limits,
+        ignore_filters=ignore_filters,
     )
     plot_data = _get_plot_data(available, splitter, row_count_bin=row_count_bin, show_removed=show_removed)
 
@@ -284,7 +287,8 @@ def _get_plot_data(
 
     if show_removed:
         kept_splits = set(splits)
-        splits = replace(splitter, n_splits=0, step=1).get_plot_data(available)[0]
+        splits = replace(splitter, ignore_filters=True).get_plot_data(available)[0]
+
         if splitter.step < 0:
             splits.reverse()
         removed = set(splits) - set(kept_splits)

--- a/src/time_split/_frontend/_split.py
+++ b/src/time_split/_frontend/_split.py
@@ -13,6 +13,7 @@ def split(
     n_splits: int = 0,
     available: DatetimeIterable | None = None,
     expand_limits: ExpandLimits = "auto",
+    ignore_filters: bool = False,
 ) -> DatetimeSplits:
     """Create time-based cross-validation splits.
 
@@ -26,6 +27,7 @@ def split(
         n_splits: {n_splits}
         available: {available} Passing a tuple ``(min, max)`` is enough.
         expand_limits: {expand_limits}
+        ignore_filters: {ignore_filters}
 
     {USER_GUIDE}
 
@@ -42,4 +44,5 @@ def split(
         step=step,
         n_splits=n_splits,
         expand_limits=expand_limits,
+        ignore_filters=ignore_filters,
     ).get_splits(available)

--- a/src/time_split/_frontend/_to_string.py
+++ b/src/time_split/_frontend/_to_string.py
@@ -2,6 +2,7 @@ from typing import Any, Literal, overload
 
 from pandas import Timestamp
 
+from .._compat import fmt_sec
 from ..settings import log_split_progress
 from ..types import DatetimeSplitBounds, DatetimeTypes
 
@@ -71,6 +72,25 @@ def to_string(
         mid=_PrettyTimestamp(mid),
         end=_PrettyTimestamp(end),
     )
+
+
+def stringify(old: Timestamp, *, new: Timestamp | None = None, diff_only: bool = False) -> str:
+    if new is None:
+        return _PrettyTimestamp(old).auto
+
+    original = f"{old} -> "
+    if old == new:
+        no_change = "<no change>"
+        if diff_only:
+            return no_change
+        return original + no_change
+    diff = (new - old).total_seconds()
+    pretty_diff = f"{'+' if diff > 0 else '-'}{fmt_sec(abs(diff))}"
+
+    if diff_only:
+        return pretty_diff
+
+    return original + f"{_PrettyTimestamp(new).auto} ({pretty_diff})"
 
 
 class _PrettyTimestamp:

--- a/src/time_split/integration/sklearn/_impl.py
+++ b/src/time_split/integration/sklearn/_impl.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Sequence
-from typing import Any, cast, get_args
+from typing import Any, Unpack, cast, get_args
 
 from numpy import array, datetime64, logical_and, ndarray, nonzero
 from numpy.typing import NDArray
@@ -7,13 +7,11 @@ from numpy.typing import NDArray
 from ..._backend import DatetimeIndexSplitter
 from ..._docstrings import docs
 from ...types import (
+    DatetimeIndexSplitterKwargs,
     DatetimeIterable,
     DatetimeSplits,
     DatetimeTypes,
-    ExpandLimits,
     MetricsType,
-    Schedule,
-    Span,
 )
 from .._log_progress import LogProgressArg, handle_log_progress_arg
 
@@ -39,14 +37,9 @@ class ScikitLearnSplitter(BaseCrossValidator):  # type: ignore[misc]
     If a ``pandas`` type is passed to the :meth:`ScikitLearnSplitter.split`-method, the index will be used.
 
     Args:
-        schedule: {schedule}
-        before: {before}
-        after: {after}
-        step: {step}
-        n_splits: {n_splits}
-        expand_limits: {expand_limits}
         log_progress: {log_progress}
         verify_xy: If ``True``, split X and y independently and verify that they are equal.
+        **kwargs: {DatetimeIndexSplitterKwargs}
 
     {USER_GUIDE}
 
@@ -54,25 +47,13 @@ class ScikitLearnSplitter(BaseCrossValidator):  # type: ignore[misc]
 
     def __init__(
         self,
-        schedule: Schedule,
         *,
-        before: Span = "7d",
-        after: Span = 1,
-        n_splits: int = 0,
-        expand_limits: ExpandLimits = "auto",
-        step: int = 1,
         log_progress: LogProgressArg[MetricsType] = False,
         verify_xy: bool = True,
+        **kwargs: Unpack[DatetimeIndexSplitterKwargs],
     ) -> None:
         super().__init__()
-        self._splitter = DatetimeIndexSplitter(
-            schedule,
-            before=before,
-            after=after,
-            step=step,
-            n_splits=n_splits,
-            expand_limits=expand_limits,
-        )
+        self._splitter = DatetimeIndexSplitter(**kwargs)
         self.log_progress = log_progress
         self.verify_xy = verify_xy
 

--- a/src/time_split/settings.py
+++ b/src/time_split/settings.py
@@ -10,11 +10,11 @@ from . import types as _tst
 class auto_expand_limits:  # noqa: N801
     """Configuration for the `'auto'` :attr:`~time_split.types.ExpandLimits` logic.
 
-    This class determines how ``(min, max)``-tuples are expanded when expand_limitsible bounds are enabled.
+    This class determines how ``(min, max)``-tuples are expanded when expanded limits are enabled.
     """
 
     SANITY_CHECK: bool = True
-    """If ``True``, use original limits if expand_limitsed limits do not pass sanity checks."""
+    """If ``True``, use original limits if expanded limits do not pass sanity checks."""
 
     @classmethod
     def set_level(
@@ -86,8 +86,8 @@ class plot:  # noqa: N801
     FUTURE_DATA_LABEL: str = "Future data"
     """Label of the red bar; data in the the [:attr:`~.DatetimeSplitBounds.mid`, :attr:`~.types.DatetimeSplitBounds.end`)-range."""
 
-    DEFAULT_TIME_UNIT: str = "h"
-    """Time unit to use by default when ``bar_labels=True`` and ``available=None``."""
+    DEFAULT_TIME_UNIT: str = "hours"
+    """Time unit to use by default when ``bar_labels=True`` and ``available=None`` or a limits tuple."""
 
     REMOVED_FOLD_STYLE: _t.ClassVar[dict[str, _t.Any]] = {
         "alpha": 0.35,

--- a/src/time_split/settings.py
+++ b/src/time_split/settings.py
@@ -2,6 +2,8 @@
 
 import typing as _t
 
+import pandas as _pd
+
 from . import types as _tst
 
 
@@ -172,3 +174,6 @@ class misc:  # noqa: N801
     If ``True``, ensure that the `Future data` of the final fold ends at the rightmost edge of the available data range.
     Otherwise, alignment is determined by :func:`pandas.date_range`.
     """
+
+    filter: _t.Callable[[_pd.Timestamp, _pd.Timestamp, _pd.Timestamp], bool] | None = None
+    """A callable ``(start, mid, end) -> bool`` applied to all generated folds."""

--- a/tests/integration/test_sklearn.py
+++ b/tests/integration/test_sklearn.py
@@ -8,7 +8,7 @@ from time_split.integration.sklearn import ScikitLearnSplitter
 
 def test_sklearn(caplog):
     # Check against pandas implementation
-    splitter = ScikitLearnSplitter("1d", log_progress={"logger": "test-sklearn", "start_level": logging.DEBUG})
+    splitter = ScikitLearnSplitter(schedule="1d", log_progress={"logger": "test-sklearn", "start_level": logging.DEBUG})
 
     index = pd.date_range("2022", "2022-1-10", freq="h")
     array = index.array
@@ -28,7 +28,7 @@ def test_sklearn(caplog):
 
 
 def test_bad_args():
-    splitter = ScikitLearnSplitter("1d", expand_limits=False)
+    splitter = ScikitLearnSplitter(schedule="1d", expand_limits=False)
     array = pd.date_range("2022", "2022-1-10", freq="h").array
 
     with pytest.raises(ValueError, match="are not equal."):
@@ -51,6 +51,6 @@ def test_cv():
         LinearRegression(),
         X=df[["x", "y"]],
         y=df["z"],
-        cv=ScikitLearnSplitter("1d"),
+        cv=ScikitLearnSplitter(schedule="1d"),
     )
     assert len(res) == 2


### PR DESCRIPTION
# Key changes
* Adds a global config attribute `settings.misc.filter`
* All kinds of filtering (`n_splits`, `step`, and `settings.misc.filter`) may be bypassed with a new `ignore_filters` keyword argument in `split()`, `plot()` and integration classes.

## Bonus content
* Print length-two data arguments as limits tuples in `plot()`.
  * Pretty-print as string in title.
  * Switch default of `bar_labels=True` from `rows` to `hours` when a limits-tuple is detected.
* Add x-axis label rotation to prevent tick label overlap.